### PR TITLE
fix renaming exec to erlexec

### DIFF
--- a/apps/fyler/src/fyler_pool.erl
+++ b/apps/fyler/src/fyler_pool.erl
@@ -58,7 +58,7 @@ init(_Args) ->
 
   self() ! connect_to_server,
 
-  ulitos_app:ensure_started(exec),
+  ulitos_app:ensure_started(erlexec),
   ulitos_app:ensure_loaded(?Handlers),
 
   Category = ?Config(category, undefined),

--- a/apps/fyler/src/handlers/video_probe.erl
+++ b/apps/fyler/src/handlers/video_probe.erl
@@ -12,7 +12,7 @@ info(Path) ->
   Command = ?CMD(Path),
   ?D({"command", Command}),
   true = filelib:is_file(Path),
-  case exec_command:run_link(Command, [stdout, monitor]) of
+  case exec:run(Command, [{stdout, self()}, monitor]) of
     {error, Error} ->
       ?E(Error),
       #video_info{audio_codec = default, video_codec = default};

--- a/apps/fyler/test/docs_conversions_tests.erl
+++ b/apps/fyler/test/docs_conversions_tests.erl
@@ -25,7 +25,7 @@ delete_files([File|Files]) ->
 
 setup_() ->
   lager:start(),
-  ulitos_app:ensure_started(exec),
+  ulitos_app:ensure_started(erlexec),
   file:make_dir(?PATH("tmp")).
 
 cleanup_(_) ->
@@ -50,7 +50,7 @@ cleanup_(_) ->
     Files4 when is_list(Files4) -> delete_files(Files4);
     _ -> false
   end,
-  application:stop(exec),
+  application:stop(erlexec),
   application:stop(lager).
 
 
@@ -77,22 +77,22 @@ doc_swftools_test_() ->
 
 doc_pdftk_test_()->
   ?setup(
-    [ 
-      {timeout, ?TIMEOUT, [pdf_split_t_()]}  
+    [
+      {timeout, ?TIMEOUT, [pdf_split_t_()]}
     ]
   ).
 
 doc_unpack_test_()->
   ?setup(
-    [ 
+    [
       {timeout, ?TIMEOUT, [zip_unpack_t_("20", "")]}
     ]
   ).
 
 doc_unpack2_test_()->
   ?setup(
-    [ 
-      {timeout, ?TIMEOUT, [zip_unpack_t_("21", "scorm")]}      
+    [
+      {timeout, ?TIMEOUT, [zip_unpack_t_("21", "scorm")]}
     ]
   ).
 
@@ -102,7 +102,7 @@ doc_to_pdf_t_() ->
     ?assertMatch({ok,#job_stats{}}, Res),
     {_, Stat} = Res,
     ?assertEqual(2, length(Stat#job_stats.result_path))
-  end.     
+  end.
 
 doc_to_pdf_2_t_() ->
   fun() ->
@@ -110,7 +110,7 @@ doc_to_pdf_2_t_() ->
     ?assertMatch({ok,#job_stats{}}, Res),
     {_, Stat} = Res,
     ?assertEqual(2, length(Stat#job_stats.result_path))
-  end.     
+  end.
 
 xls_to_pdf_t_() ->
   fun() ->
@@ -118,7 +118,7 @@ xls_to_pdf_t_() ->
     ?assertMatch({ok,#job_stats{}}, Res),
     {_, Stat} = Res,
     ?assertEqual(2, length(Stat#job_stats.result_path))
-  end.    
+  end.
 
 xls_to_pdf_2_t_() ->
   fun() ->
@@ -126,7 +126,7 @@ xls_to_pdf_2_t_() ->
     ?assertMatch({ok,#job_stats{}}, Res),
     {_, Stat} = Res,
     ?assertEqual(2, length(Stat#job_stats.result_path))
-  end.  
+  end.
 
 ppt_to_pdf_t_() ->
   fun() ->
@@ -134,7 +134,7 @@ ppt_to_pdf_t_() ->
     ?assertMatch({ok,#job_stats{}}, Res),
     {_, Stat} = Res,
     ?assertEqual(2, length(Stat#job_stats.result_path))
-  end.     
+  end.
 
 doc_to_pdf_swf_t_() ->
   fun() ->
@@ -142,7 +142,7 @@ doc_to_pdf_swf_t_() ->
     ?assertMatch({ok,#job_stats{}}, Res),
     {_, Stat} = Res,
     ?assertEqual(3, length(Stat#job_stats.result_path))
-  end.  
+  end.
 
 doc_to_pdf_thumbs_t_() ->
   fun() ->
@@ -150,7 +150,7 @@ doc_to_pdf_thumbs_t_() ->
     ?assertMatch({ok,#job_stats{}}, Res),
     {_, Stat} = Res,
     ?assertEqual(2, length(Stat#job_stats.result_path))
-  end.  
+  end.
 
 pdf_split_t_() ->
   fun() ->
@@ -169,7 +169,7 @@ pdf_to_swf_t_() ->
     ?assertMatch({ok,#job_stats{}}, Res),
     {_, Stat} = Res,
     ?assertEqual(1, length(Stat#job_stats.result_path))
-  end. 
+  end.
 
 pdf_to_swf_thumbs_t_() ->
   fun() ->
@@ -177,13 +177,12 @@ pdf_to_swf_thumbs_t_() ->
     ?assertMatch({ok,#job_stats{}}, Res),
     {_, Stat} = Res,
     ?assertEqual(2, length(Stat#job_stats.result_path))
-  end. 
+  end.
 
 zip_unpack_t_(Name, To) ->
   fun() ->
-
     Res = unpack_html:run(#file{tmp_path = ?PATH(Name++".zip"), name = Name, dir = ?PATH(To), extension = "zip"}),
     ?assertMatch({ok,#job_stats{}}, Res),
     {_, Stat} = Res,
     ?assertEqual(1, length(Stat#job_stats.result_path))
-  end. 
+  end.

--- a/apps/fyler/test/video_conversions_tests.erl
+++ b/apps/fyler/test/video_conversions_tests.erl
@@ -26,7 +26,7 @@ delete_files([File|Files]) ->
 setup_() ->
   lager:start(),
   media:start(),
-  ulitos_app:ensure_started(exec),
+  ulitos_app:ensure_started(erlexec),
   file:make_dir(?PATH("tmp")).
 
 cleanup_(_) ->
@@ -55,7 +55,7 @@ cleanup_(_) ->
     Files4 when is_list(Files4) -> delete_files(Files4);
     _ -> false
   end,
-  application:stop(exec),
+  application:stop(erlexec),
   application:stop(lager).
 
 video_mp4_test_() ->

--- a/apps/fyler/test/video_conversions_tests.erl
+++ b/apps/fyler/test/video_conversions_tests.erl
@@ -284,7 +284,7 @@ mp3_to_ogg_t_() ->
 
 video_probe_flv_speex_t_() ->
   fun() ->
-    ?assertMatch(#video_info{audio_codec="libspeex", video_codec="h264"}, video_probe:info(?PATH("stream_1.flv")))
+    ?assertMatch(#video_info{audio_codec="speex", video_codec="h264"}, video_probe:info(?PATH("stream_1.flv")))
   end.
 
 video_probe_screen_share_t_() ->

--- a/rebar_pool_document.config
+++ b/rebar_pool_document.config
@@ -12,7 +12,7 @@
   {hackney, ".*", {git, "https://github.com/benoitc/hackney.git", "1.2.0"}},
   {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git","master"}},
   {ulitos, ".*", {git, "https://github.com/palkan/ulitos.git", {tag, "v0.2.0"}}},
-  {exec, ".*", {git, "https://github.com/saleyn/erlexec.git", "master"}},
+  {erlexec, ".*", {git, "https://github.com/saleyn/erlexec.git", "master"}},
   {lager_honeybadger_backend, ".*", {git, "https://github.com/fyler/lager_honeybadger_backend.git", {branch, "master"}}},
   {lager_logstash_backend, ".*", {git, "https://github.com/mhald/lager_logstash_backend.git", {branch, "master"}}}
 ]}.

--- a/rebar_pool_video.config
+++ b/rebar_pool_video.config
@@ -13,7 +13,7 @@
   {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git","master"}},
   {ulitos, ".*", {git, "https://github.com/palkan/ulitos.git", {tag, "v0.2.0"}}},
   {media, ".*", {git, "https://github.com/fyler/media.git", {branch, "master"}}},
-  {exec, ".*", {git, "https://github.com/saleyn/erlexec.git", "master"}},
+  {erlexec, ".*", {git, "https://github.com/saleyn/erlexec.git", "master"}},
   {lager_honeybadger_backend, ".*", {git, "https://github.com/fyler/lager_honeybadger_backend.git", {branch, "master"}}},
   {lager_logstash_backend, ".*", {git, "https://github.com/mhald/lager_logstash_backend.git", {branch, "master"}}}
 ]}.


### PR DESCRIPTION
Hi, project `exec` renamed https://github.com/saleyn/erlexec/blob/master/CHANGELOG.txt, I fixed it
